### PR TITLE
Alert-20 fix

### DIFF
--- a/supabase/functions/mono-webhook/index.ts
+++ b/supabase/functions/mono-webhook/index.ts
@@ -4,7 +4,7 @@
 // Приймає callback від monobank і викликає admin-manual-convert
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const ADMIN_KEY    = Deno.env.get("ADMIN_EXPORT_KEYS")!;
-const FUNCTIONS_BASE = `${SUPABASE_URL.replace(".supabase.co","").replace("https://","https://")}.functions.supabase.co`;
+const FUNCTIONS_BASE = `${SUPABASE_URL.replace(".supabase.co","")}.functions.supabase.co`;
 
 // TODO: валідація X-Signature за докою mono (якщо ввімкнена)
 function verifyMono(_req:Request, _body:any){ return true; }


### PR DESCRIPTION
Potential fix for [https://github.com/CortexFin-App/wislet/security/code-scanning/20](https://github.com/CortexFin-App/wislet/security/code-scanning/20)

The best fix is to remove the `.replace("https://", "https://")` call entirely from the line constructing `FUNCTIONS_BASE`, as it has no effect and clutters the code. Retain only the `.replace(".supabase.co","")` replacement, which appears intentional to strip the `.supabase.co` from the hostname, and then append `.functions.supabase.co` as designed. Edit line 7 in `supabase/functions/mono-webhook/index.ts` to remove the unnecessary replacement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
